### PR TITLE
Add Jump Point Search and UI buttons

### DIFF
--- a/Game.h
+++ b/Game.h
@@ -12,10 +12,13 @@
 #include "Resource.h"	
 #include "GameEngine.h"
 #include "AbstractGame.h"
+#include <memory>
 
 //-----------------------------------------------------------------
 // Game Class																
 //-----------------------------------------------------------------
+class JumpPointSearch; // forward declaration
+
 class Game : public AbstractGame, public Callable
 {
 public:				
@@ -56,18 +59,29 @@ private:
 	// -------------------------
 
 
-	enum class CellType { Empty, Start, Destination, Obstacle };
+        enum class CellType { Empty, Start, Destination, Obstacle, Path };
 
 	static const int GRID_COLS{ 20 };
 	static const int GRID_ROWS{ 15 };
 	static const int CELL_SIZE{ 32 };
 
-	std::vector<CellType> mGrid;
-	CellType mCurrentBrush{ CellType::Obstacle };
-	POINT mStartCell{ -1, -1 };
-	POINT mDestCell{ -1, -1 };
+        std::vector<CellType> mGrid;
+        CellType mCurrentBrush{ CellType::Obstacle };
+        POINT mStartCell{ -1, -1 };
+        POINT mDestCell{ -1, -1 };
 
-	std::wstring m_BrushType = L"undefined"; 
+        std::wstring m_BrushType = L"undefined";
 
+        // UI Buttons
+        Button* mBtnStart{ nullptr };
+        Button* mBtnDest{ nullptr };
+        Button* mBtnObstacle{ nullptr };
+        Button* mBtnEmpty{ nullptr };
+        Button* mBtnSolve{ nullptr };
+        Button* mBtnStep{ nullptr };
 
+        std::unique_ptr<JumpPointSearch> mJps;
+        bool mStepping{ false };
+
+        void ClearPath();
 };

--- a/JumpPointSearch.cpp
+++ b/JumpPointSearch.cpp
@@ -1,0 +1,204 @@
+#include "JumpPointSearch.h"
+#include "Game.h"
+#include <cmath>
+
+JumpPointSearch::JumpPointSearch(const std::vector<CellType>& grid, int cols, int rows)
+    : mGrid(grid), mCols(cols), mRows(rows)
+{
+}
+
+void JumpPointSearch::SetStart(POINT start)
+{
+    mStart = start;
+}
+
+void JumpPointSearch::SetGoal(POINT goal)
+{
+    mGoal = goal;
+}
+
+void JumpPointSearch::Reset()
+{
+    mPath.clear();
+    mFinished = false;
+    for (auto& pair : mNodes)
+        delete pair.second;
+    mNodes.clear();
+    mClosed.clear();
+    while (!mOpen.empty()) mOpen.pop();
+}
+
+std::vector<POINT> JumpPointSearch::Solve()
+{
+    while (!Step())
+    {
+    }
+    return mPath;
+}
+
+bool JumpPointSearch::Step()
+{
+    if (mFinished) return true;
+
+    if (mOpen.empty())
+    {
+        Node* startNode = GetNode(mStart.x, mStart.y);
+        startNode->g = 0.0;
+        startNode->h = Heuristic(mStart.x, mStart.y);
+        mOpen.push(startNode);
+    }
+
+    if (mOpen.empty())
+    {
+        mFinished = true;
+        return true; // no path
+    }
+
+    Node* current = mOpen.top();
+    mOpen.pop();
+    int currentIndex = Index(current->x, current->y);
+    if (mClosed.count(currentIndex))
+    {
+        return false;
+    }
+    mClosed.insert(currentIndex);
+
+    if (current->x == mGoal.x && current->y == mGoal.y)
+    {
+        mFinished = true;
+        // reconstruct path
+        mPath.clear();
+        Node* n = current;
+        while (n)
+        {
+            mPath.push_back(POINT{ n->x, n->y });
+            n = n->parent;
+        }
+        std::reverse(mPath.begin(), mPath.end());
+        return true;
+    }
+
+    auto neighbors = GetNeighbors(current);
+    for (auto& dir : neighbors)
+    {
+        int nx = dir.first;
+        int ny = dir.second;
+        int dx = nx - current->x;
+        int dy = ny - current->y;
+        Node* jumpNode = Jump(nx, ny, dx, dy);
+        if (!jumpNode) continue;
+        int jIndex = Index(jumpNode->x, jumpNode->y);
+        if (mClosed.count(jIndex)) continue;
+
+        double newG = current->g + std::hypot(jumpNode->x - current->x, jumpNode->y - current->y);
+        if (jumpNode->parent == nullptr || newG < jumpNode->g)
+        {
+            jumpNode->g = newG;
+            jumpNode->h = Heuristic(jumpNode->x, jumpNode->y);
+            jumpNode->parent = current;
+            mOpen.push(jumpNode);
+        }
+    }
+
+    return false;
+}
+
+JumpPointSearch::Node* JumpPointSearch::GetNode(int x, int y)
+{
+    int index = Index(x, y);
+    auto it = mNodes.find(index);
+    if (it != mNodes.end()) return it->second;
+    Node* n = new Node{};
+    n->x = x;
+    n->y = y;
+    mNodes[index] = n;
+    return n;
+}
+
+bool JumpPointSearch::IsWalkable(int x, int y) const
+{
+    if (x < 0 || y < 0 || x >= mCols || y >= mRows) return false;
+    CellType cell = mGrid[Index(x, y)];
+    return cell != CellType::Obstacle;
+}
+
+double JumpPointSearch::Heuristic(int x, int y) const
+{
+    return std::abs(x - mGoal.x) + std::abs(y - mGoal.y);
+}
+
+JumpPointSearch::Node* JumpPointSearch::Jump(int x, int y, int dx, int dy)
+{
+    if (!IsWalkable(x, y)) return nullptr;
+    if (x == mGoal.x && y == mGoal.y) return GetNode(x, y);
+
+    // forced neighbor detection for 4-directional movement
+    if (dx != 0)
+    {
+        if ((IsWalkable(x, y - 1) && !IsWalkable(x - dx, y - 1)) ||
+            (IsWalkable(x, y + 1) && !IsWalkable(x - dx, y + 1)))
+        {
+            return GetNode(x, y);
+        }
+    }
+    else if (dy != 0)
+    {
+        if ((IsWalkable(x - 1, y) && !IsWalkable(x - 1, y - dy)) ||
+            (IsWalkable(x + 1, y) && !IsWalkable(x + 1, y - dy)))
+        {
+            return GetNode(x, y);
+        }
+    }
+
+    if (dx != 0 && dy != 0)
+    {
+        // not used (4-directional)
+    }
+
+    return Jump(x + dx, y + dy, dx, dy);
+}
+
+std::vector<std::pair<int, int>> JumpPointSearch::GetNeighbors(Node* node)
+{
+    std::vector<std::pair<int, int>> neighbors;
+
+    if (node->parent)
+    {
+        int dx = (node->x - node->parent->x); if (dx != 0) dx /= std::abs(dx);
+        int dy = (node->y - node->parent->y); if (dy != 0) dy /= std::abs(dy);
+
+        if (dx != 0)
+        {
+            if (IsWalkable(node->x + dx, node->y))
+                neighbors.emplace_back(node->x + dx, node->y);
+            if (!IsWalkable(node->x, node->y + 1) && IsWalkable(node->x + dx, node->y + 1))
+                neighbors.emplace_back(node->x + dx, node->y + 1);
+            if (!IsWalkable(node->x, node->y - 1) && IsWalkable(node->x + dx, node->y - 1))
+                neighbors.emplace_back(node->x + dx, node->y - 1);
+        }
+        else if (dy != 0)
+        {
+            if (IsWalkable(node->x, node->y + dy))
+                neighbors.emplace_back(node->x, node->y + dy);
+            if (!IsWalkable(node->x + 1, node->y) && IsWalkable(node->x + 1, node->y + dy))
+                neighbors.emplace_back(node->x + 1, node->y + dy);
+            if (!IsWalkable(node->x - 1, node->y) && IsWalkable(node->x - 1, node->y + dy))
+                neighbors.emplace_back(node->x - 1, node->y + dy);
+        }
+    }
+    else
+    {
+        // return all neighbors
+        const int dirs[4][2] = { {1,0},{-1,0},{0,1},{0,-1} };
+        for (auto& d : dirs)
+        {
+            int nx = node->x + d[0];
+            int ny = node->y + d[1];
+            if (IsWalkable(nx, ny))
+                neighbors.emplace_back(nx, ny);
+        }
+    }
+
+    return neighbors;
+}
+

--- a/JumpPointSearch.h
+++ b/JumpPointSearch.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <vector>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+#include <windows.h>
+
+enum class CellType : int;
+
+class JumpPointSearch
+{
+public:
+    JumpPointSearch(const std::vector<CellType>& grid, int cols, int rows);
+
+    void SetStart(POINT start);
+    void SetGoal(POINT goal);
+
+    // Solve the entire path at once
+    std::vector<POINT> Solve();
+
+    // Perform a single iteration of the algorithm
+    // Returns true when finished (either path found or no path)
+    bool Step();
+
+    const std::vector<POINT>& GetPath() const { return mPath; }
+    void Reset();
+
+private:
+    struct Node
+    {
+        int x{};
+        int y{};
+        double g{};
+        double h{};
+        Node* parent{ nullptr };
+        double F() const { return g + h; }
+    };
+
+    struct NodeCompare
+    {
+        bool operator()(const Node* a, const Node* b) const { return a->F() > b->F(); }
+    };
+
+    Node* GetNode(int x, int y);
+    Node* Jump(int x, int y, int dx, int dy);
+    std::vector<std::pair<int, int>> GetNeighbors(Node* node);
+    bool IsWalkable(int x, int y) const;
+    double Heuristic(int x, int y) const;
+    int Index(int x, int y) const { return y * mCols + x; }
+
+    const std::vector<CellType>& mGrid;
+    int mCols{};
+    int mRows{};
+    POINT mStart{ -1, -1 };
+    POINT mGoal{ -1, -1 };
+
+    std::priority_queue<Node*, std::vector<Node*>, NodeCompare> mOpen;
+    std::unordered_map<int, Node*> mNodes;
+    std::unordered_set<int> mClosed;
+    std::vector<POINT> mPath;
+    bool mFinished{ false };
+};
+


### PR DESCRIPTION
## Summary
- implement Jump Point Search pathfinding with step and full-solve modes
- add on-screen buttons for brush selection, solving, and stepping through the algorithm
- render path cells and switch brush selection from keyboard to button controls

## Testing
- `g++ -std=c++17 -c Game.cpp GameEngine.cpp AbstractGame.cpp Grid.cpp JumpPointSearch.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c9fac5288329a7429bb9960a9bba